### PR TITLE
Remove extraneous ` char from #include <assert.h>

### DIFF
--- a/mic/events.cpp
+++ b/mic/events.cpp
@@ -24,7 +24,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <unistd.h>
 #include <err.h>
 #include <sys/resource.h>
-#include <assert.h>`
+#include <assert.h>
 #include <immintrin.h>
 
 #include "perf_utils.h"


### PR DESCRIPTION
The ` mark is causing build failures with non-icc compilers, remove it

Signed-off-by: Colin Ian King colin.king@canonical.com
